### PR TITLE
Fix TypeError: can't use a string pattern on a bytes-like object

### DIFF
--- a/hubo/cs1robots.py
+++ b/hubo/cs1robots.py
@@ -269,7 +269,7 @@ def load_world(filename = None):
                                     "Robot World", '*', [ "*.wld" ])
     if not filename:
       raise RuntimeError("No world file selected.")
-  txt = open(filename, 'rb').read()
+  txt = open(filename, 'rb').read().decode("utf-8")
   txt = _re.sub('\r\n', '\n', txt) # Windows
   txt = _re.sub('\r', '\n', txt)  # Mac
   _check_world(txt)


### PR DESCRIPTION
This fixes a bug in `load_world` when used with recent Python 3's. Tested on both Windows machines and Macs.